### PR TITLE
Bump Node.js version to 16.x LTS

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: Test Build
         run: |
           if [ -e yarn.lock ]; then


### PR DESCRIPTION
CI was failing on #1 due to an outdated Node.js version for the `checks` run.